### PR TITLE
Backoff version to 1.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-freshdesk',
       install_requires=[
           'singer-python @ git+https://github.com/peliqan-io/singer-python@master',
           'requests==2.20.0',
-          'backoff==1.3.2'
+          'backoff==1.8.0'
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
# Description of change
Change backoff version to 1.8.0 to match singer-python's backoff version

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
