### PR TITLE
Use singer's utils.pars_args instead of local utils

### DIFF
--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -241,9 +241,9 @@ def do_sync():
 
 
 def main_impl():
-    config, state = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-    CONFIG.update(config)
-    STATE.update(state)
+    args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
+    CONFIG.update(args.config)
+    STATE.update(args.state)
     do_sync()
 
 

--- a/tap_freshdesk/__init__.py
+++ b/tap_freshdesk/__init__.py
@@ -241,7 +241,7 @@ def do_sync():
 
 
 def main_impl():
-    config, state = utils.parse_args(REQUIRED_CONFIG_KEYS)
+    config, state = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     CONFIG.update(config)
     STATE.update(state)
     do_sync()


### PR DESCRIPTION
# Description of change
Use singer's utils.pars_args instead of local utils

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
